### PR TITLE
feat: support wiki-link syntax for local images

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -105,7 +105,12 @@ export default class ContactCardsPlugin extends Plugin {
 		ctx: MarkdownPostProcessorContext,
 	) {
 		try {
-			const contactData = parseYaml(source) ?? {
+			// Quote wiki-link values (e.g., ![[image.png]]) to prevent YAML tag parse errors
+			const sanitized = source.replace(
+				/(:\s*)(!?\[\[.+?\]\])\s*$/gm,
+				'$1"$2"',
+			);
+			const contactData = parseYaml(sanitized) ?? {
 				name: "John Doe",
 				title: "The Everyman",
 				company: "Acme Inc.",


### PR DESCRIPTION
## Summary

Add support for Obsidian wiki-link syntax (`![[image.png]]`) in `photo_url` and `logo_url` fields, enabling local vault images on contact cards. Also introduces `photo` and `logo` as shorter field aliases.

Closes #3

## Changes

- Add `resolveWikiLink()` helper that resolves `![[...]]` / `[[...]]` syntax to vault resource paths via Obsidian's `parseLinktext` and `metadataCache` APIs
- Add `isWikiLink()` helper for detecting wiki-link syntax on unresolvable values
- Normalize `photo` → `photo_url` and `logo` → `logo_url` aliases (deleted after normalization to prevent rendering as custom fields)
- Resolve wiki-links in both `photo_url` and `logo_url` before rendering
- Gracefully fall back to Gravatar/Logo.dev when a wiki-link target file is not found (instead of rendering a broken image)
- Pre-process YAML source to auto-quote wiki-link values, preventing `!` from being interpreted as a YAML tag indicator (fixes `YAMLParseError` on unquoted `![[...]]` syntax)

## Example Usage

```yaml
photo: ![[headshot.png]]
logo: ![[company-logo.svg]]
name: John Doe
email: john@test.net
company: Big Company
title: CEO
```

## Testing

- `npm run build` — passes (tsc + esbuild)
- `npm run lint` — passes (Trunk)
- Manual verification scenarios:
  - `photo: ![[some-image.png]]` resolves and displays local image (no quoting needed)
  - `logo: ![[logo.svg]]` resolves and displays local logo (no quoting needed)
  - `photo_url: "![[some-image.png]]"` still works when manually quoted
  - `photo_url: https://...` still works as a plain URL
  - Missing wiki-link target gracefully falls back to Gravatar/Logo.dev
  - Cards without local images render identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to parsing/resolving optional image fields and input sanitization, with conservative fallbacks when resolution fails.
> 
> **Overview**
> Adds support for Obsidian wiki-link image references (e.g. `![[headshot.png]]` / `[[logo.svg]]`) in contact card `photo_url` and `logo_url` fields by resolving them to vault resource URLs based on the current note’s `sourcePath`.
> 
> Introduces `photo`/`logo` as aliases for `photo_url`/`logo_url`, sanitizes YAML input by auto-quoting wiki-link values to avoid YAML tag parse errors, and treats unresolvable wiki-links as missing so the existing Gravatar/Logo.dev fallbacks are used instead of rendering broken images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7142e8d0c281a1aae9d190011cd54428dc63b027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->