### PR TITLE
Add local image documentation and fix release-please CI lint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,6 +16,10 @@ runtimes:
         - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
+    ignore:
+        - linters: [ALL]
+          paths:
+              - CHANGELOG.md
     enabled:
         - checkov@3.2.370
         - eslint@8.57.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,19 @@ This is an Obsidian plugin that renders YAML code blocks (fenced as `contact-car
 
 ### Contact Card Fields
 
-Standard fields with special handling: `name`, `email`, `phone`, `company`, `title`, `location`, `domain`, `photo_url`, `logo_url`. Any additional YAML keys render as generic key-value rows.
+Standard fields with special handling: `name`, `email`, `phone`, `company`, `title`, `location`, `domain`, `photo_url`, `logo_url`. Shorthand aliases `photo` and `logo` map to `photo_url` and `logo_url`. Any additional YAML keys render as generic key-value rows.
 
 Phone formatting uses `google-libphonenumber` with the configured default country code.
+
+### Wiki-Link Image Resolution
+
+The `photo_url` and `logo_url` fields support Obsidian wiki-link syntax (`[[image.png]]` or `![[image.png]]`). Key helpers:
+
+- **`WIKI_LINK_RE`** — Static regex matching both `[[...]]` and `![[...]]` forms.
+- **`resolveWikiLink()`** — Resolves a wiki-link to a vault resource path via `parseLinktext` and `metadataCache`.
+- **`resolveImageField()`** — Wraps resolution with fallback: resolved path, `null` if link is broken, or original value if not a wiki-link.
+
+YAML values like `![[image.png]]` are auto-quoted during parsing to prevent YAML tag errors.
 
 ### Rendering Approach
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ The Obsidian Contact Cards Plugin transforms YAML data inside a special code blo
 **View the rendered card** in Reading/Preview mode:
 ![Sample Card](sample_card.png)
 
+### Local Images
+
+You can use Obsidian wiki-link syntax to reference images from your vault for the contact photo or company logo:
+
+````md
+    ```contact-card
+    name: Bryan Stone
+    photo: [[headshot.png]]
+    logo: ![[company-logo.png]]
+    company: Steampunk Labs
+    title: Founder & Managing Partner
+    ```
+````
+
+Both `[[...]]` and `![[...]]` forms are supported. The plugin resolves the link to the corresponding file in your vault. If the linked file is not found, the field is silently ignored (falling back to Gravatar for photos, or Logo.dev for logos).
+
+The `photo` and `logo` fields are shorthand aliases for `photo_url` and `logo_url` respectively — you can use either form.
+
 ## Customization
 
 The `obsidian-contact-cards` plugin allows for several customizable settings to tailor the behavior and design of your contact cards. Below are the available options you can configure:


### PR DESCRIPTION
## Summary

Adds user-facing documentation for the wiki-link local image feature and fixes the CI lint failure on the release-please PR by excluding the auto-generated CHANGELOG.md from trunk linting.

## Changes

- **README.md**: Document wiki-link syntax (`[[image.png]]` / `![[image.png]]`) for `photo` and `logo` fields with usage example
- **CLAUDE.md**: Add wiki-link image resolution architecture docs (field aliases, helper methods, YAML sanitization)
- **.trunk/trunk.yaml**: Ignore `CHANGELOG.md` in all linters — release-please generates duplicate headings and non-prettier formatting that are valid for changelogs

## Testing

- `trunk check --all` passes locally
- `npm run build` passes
- `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)